### PR TITLE
Fix missing Gemini API key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,13 @@ NEXT_PUBLIC_FIREBASE_APP_ID=your-app-id
 ```
 
 Run the development server with `npm run dev`.
+
+To enable AI-generated motivation messages, include your Google AI (Gemini)
+API key as well:
+
+```
+GEMINI_API_KEY=your-gemini-api-key
+```
+
+The application also accepts `GOOGLE_API_KEY`, `NEXT_PUBLIC_GEMINI_API_KEY`, or
+`NEXT_PUBLIC_GOOGLE_API_KEY` for convenience.

--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -1,7 +1,17 @@
 import {genkit} from 'genkit';
 import {googleAI} from '@genkit-ai/googleai';
 
+// Allow the Google AI plugin to receive an API key from various environment
+// variables. This helps avoid runtime failures when the expected `GEMINI_API_KEY`
+// or `GOOGLE_API_KEY` variables are not set but an alternative (e.g. prefixed
+// with `NEXT_PUBLIC_`) is provided.
+const googleApiKey =
+  process.env.GOOGLE_API_KEY ||
+  process.env.GEMINI_API_KEY ||
+  process.env.NEXT_PUBLIC_GOOGLE_API_KEY ||
+  process.env.NEXT_PUBLIC_GEMINI_API_KEY;
+
 export const ai = genkit({
-  plugins: [googleAI()],
+  plugins: [googleAI({ apiKey: googleApiKey })],
   model: 'googleai/gemini-2.0-flash',
 });


### PR DESCRIPTION
## Summary
- let gemini API key be provided via several env vars in `genkit.ts`
- document required environment variable for AI features

## Testing
- `npm run typecheck` *(fails: no overload matches this call)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c4a5ec2c88329962aa8a341e1c88a