### PR TITLE
Integrate provided API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To enable AI-generated motivation messages, include your Google AI (Gemini)
 API key as well:
 
 ```
-GEMINI_API_KEY=your-gemini-api-key
+GEMINI_API_KEY=AIzaSyB-RIjhhODp6aPTzqVcwbXD894oebXFCUY
 ```
 
 The application also accepts `GOOGLE_API_KEY`, `NEXT_PUBLIC_GEMINI_API_KEY`, or

--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -9,7 +9,8 @@ const googleApiKey =
   process.env.GOOGLE_API_KEY ||
   process.env.GEMINI_API_KEY ||
   process.env.NEXT_PUBLIC_GOOGLE_API_KEY ||
-  process.env.NEXT_PUBLIC_GEMINI_API_KEY;
+  process.env.NEXT_PUBLIC_GEMINI_API_KEY ||
+  'AIzaSyB-RIjhhODp6aPTzqVcwbXD894oebXFCUY';
 
 export const ai = genkit({
   plugins: [googleAI({ apiKey: googleApiKey })],


### PR DESCRIPTION
## Summary
- wire default Gemini API key into AI plugin
- document Gemini API key usage

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck` *(fails: existing TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_687c4c746e088329a14a638601262f08